### PR TITLE
Play /management URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ project/boot/
 .idea/
 out/
 
+# stuff to ignore from play
+example-play/logs

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import java.util.jar._
 
-crossScalaVersions in ThisBuild := Seq("2.8.1", "2.9.0-1", "2.9.1")
+crossScalaVersions in ThisBuild := Seq("2.9.1")
 
 // doing "in ThisBuild" makes this default setting for all projects in this build
 version in ThisBuild := "5.7-SNAPSHOT"

--- a/example-play/app/controllers/Management.scala
+++ b/example-play/app/controllers/Management.scala
@@ -1,0 +1,46 @@
+package controllers
+
+import com.gu.management._
+import com.gu.management.play.ManagementController
+import com.gu.management.logback._
+
+// example of creating your own new page type
+class DummyPage extends ManagementPage {
+  val path = "/management/dummy"
+  def get(request: HttpRequest) = PlainTextResponse("Hello dummy!")
+}
+
+// switches
+object Switches {
+  val omniture = new DefaultSwitch("omniture", "enables omniture java script")
+  val takeItDown = new DefaultSwitch("take-it-down", "enable this switch to take the site down", initiallyOn = false)
+
+  val all = List(omniture, takeItDown, Healthcheck.switch)
+}
+
+// timing stuff
+object TimingMetrics {
+  val downtime = new TimingMetric("example", "downtime", "downtime", "Amount of downtime")
+  val requests = new TimingMetric("example", "requests", "requests", "Number of requests recieved")
+
+  val all = List(downtime, requests)
+}
+
+// properties
+object Properties {
+  // If I were using com.gu.configuration I'd comment out the following line
+  // val all = new ConfigurationFactory getConfiguration ("music", "conf/arts_music").toString
+  val all = "key1=value1\nkey2=value2"
+}
+
+object Management extends ManagementController {
+  lazy val pages = List(
+    new DummyPage(),
+    new ManifestPage(),
+    new Switchboard(Switches.all),
+    StatusPage("Example", ExceptionCountMetric :: ServerErrorCounter :: ClientErrorCounter :: TimingMetrics.all),
+    new HealthcheckManagementPage(),
+    new PropertiesPage(Properties.all),
+    new LogbackLevelPage()
+  )
+}

--- a/example-play/app/controllers/ScalaApp.scala
+++ b/example-play/app/controllers/ScalaApp.scala
@@ -1,0 +1,36 @@
+package controllers
+
+import play.api.mvc._
+import com.gu.management.Switch.On
+import play.api.libs.concurrent.Akka
+
+object ScalaApp extends Controller {
+  def apply() = Action {
+    TimingMetrics.requests measure {
+      Switches.takeItDown match {
+        case On() => InternalServerError("Temporarily switched off!")
+        case _ => Ok("Thank you for invoking this app!")
+      }
+    }
+  }
+
+  def exception() = Action {
+    throw new Exception("Expected exception.")
+    InternalServerError("Unreachable")
+  }
+
+  def long() = Action {
+    Thread.sleep(2000)
+    Ok("Slept OK")
+  }
+
+  def async() = Action {
+    Async {
+      import play.api.Play.current
+      Akka.future {
+        Thread.sleep(2000)
+        Ok("Slept OK")
+      }
+    }
+  }
+}

--- a/example-play/build.sbt
+++ b/example-play/build.sbt
@@ -1,0 +1,4 @@
+
+publishArtifact := false
+
+seq(scalariformSettings: _*)

--- a/example-play/conf/application.conf
+++ b/example-play/conf/application.conf
@@ -1,0 +1,21 @@
+# This is the main configuration file for the application.
+# ~~~~~
+
+# Secret key
+# ~~~~~
+# The secret key is used to secure cryptographics functions.
+# If you deploy your application to several instances be sure to use the same key!
+application.secret="gAGb;Q______THIS_IS_NOT_A_SECRET_ANYMORE_____CTCA?ZcxlvS/GL^aDK"
+
+# The application languages
+# ~~~~~
+application.langs="en"
+
+
+# Logger
+# ~~~~~
+# You can also configure logback (http://logback.qos.ch/), by providing a logger.xml file in the conf directory.
+
+logger.root=INFO
+logger.play=INFO
+logger.application=DEBUG

--- a/example-play/conf/routes
+++ b/example-play/conf/routes
@@ -1,0 +1,6 @@
+GET     /scala-app                  controllers.ScalaApp.apply()
+GET     /scala-app/long             controllers.ScalaApp.long()
+GET     /scala-app/exception        controllers.ScalaApp.exception()
+GET     /scala-app/async            controllers.ScalaApp.async()
+GET     /management$path<.*>        controllers.Management.apply(path)
+POST    /management$path<.*>        controllers.Management.apply(path)

--- a/management-play/build.sbt
+++ b/management-play/build.sbt
@@ -1,0 +1,14 @@
+
+libraryDependencies ++= Seq(
+    "play" %% "play" % "2.0",
+    "org.specs2" %% "specs2" % "1.5" % "test",
+    "play" %% "play-test" % "2.0" % "test"
+)
+
+// needed for Play
+resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+
+// disable publishing the main javadoc jar
+publishArtifact in (Compile, packageDoc) := false
+
+seq(scalariformSettings: _*)

--- a/management-play/src/main/scala/com/gu/management/play/ManagementController.scala
+++ b/management-play/src/main/scala/com/gu/management/play/ManagementController.scala
@@ -1,0 +1,38 @@
+package com.gu.management.play
+
+import _root_.play.api.mvc.{ Action, Controller }
+import com.gu.management._
+
+trait ManagementController extends Controller with Loggable {
+  lazy val version = ManagementBuildInfo.version
+
+  logger.info("Management controller v%s initialised" format version)
+
+  def apply(path: String) = Action { request =>
+    request match {
+      case _ if request.path.endsWith("/") =>
+        Redirect(request.path.replaceAll("/$", ""))
+
+      case _ =>
+        val httpRequest = PlayHttpRequest(request)
+        val httpResponse = PlayHttpResponse(this)
+
+        val page = pagesWithIndex find { _ canDispatch httpRequest }
+        val dispatched = page map { _ dispatch httpRequest } getOrElse {
+          ErrorResponse(404, "No management page for: " + httpRequest.path)
+        }
+
+        dispatched to httpResponse
+
+        httpResponse.result
+    }
+  }
+
+  lazy val pagesWithIndex = IndexPage(pages, version) :: pages
+
+  /**
+   * Implement this member with a list of the management pages
+   * you want to include
+   */
+  val pages: List[ManagementPage]
+}

--- a/management-play/src/main/scala/com/gu/management/play/PlayHttp.scala
+++ b/management-play/src/main/scala/com/gu/management/play/PlayHttp.scala
@@ -1,0 +1,60 @@
+package com.gu.management.play
+
+import play.api.mvc.{ Result, Results, Request }
+import play.api.libs.json.Json
+import net.liftweb.json.{ compact, render }
+import com.gu.management._
+
+object PlayHttpRequest {
+  def apply[A](request: Request[A]): HttpRequest =
+    HttpRequest(
+      Method(request.method),
+      request.path,
+      request.requestURI,
+      request.parameters
+    )
+}
+
+case class PlayHttpResponse(results: Results) extends HttpResponse {
+  var contentType: String = "text/html"
+  var status: Int = 200
+  var body: ResponseBody = _
+  var result: Result = _
+
+  def send() {
+    var simpleResult = body match {
+      case TextResponseBody(text) => results.Status(status)(text)
+      case HtmlResponseBody(html) => results.Status(status)(html)
+      case XmlResponseBody(xml) => results.Status(status)(xml)
+      case JsonResponseBody(json) => results.Status(status)(Json.parse(compact(render(json))))
+      case NoResponseBody => results.Status(status)
+    }
+
+    headers foreach { header =>
+      simpleResult = simpleResult.withHeaders(header)
+    }
+
+    result = simpleResult as "%s; charset=%s".format(contentType, encoding)
+  }
+
+  def sendError(code: Int, message: String) {
+    status = code
+    contentType = "text/html"
+    body = HtmlResponseBody(
+      <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+          <title>Error { code } { message }</title>
+        </head>
+        <body>
+          <h2>HTTP ERROR { code }</h2>
+          <p>Reason:<pre>{ message }</pre></p>
+          <hr/>
+          <i><small>Powered by Play://</small></i>
+          <br/>
+        </body>
+      </html>
+    )
+    send()
+  }
+}
+

--- a/management-play/src/main/scala/com/gu/management/play/package.scala
+++ b/management-play/src/main/scala/com/gu/management/play/package.scala
@@ -1,0 +1,23 @@
+package com.gu.management.play
+
+import play.api.mvc.{ AnyContent, Request }
+import com.gu.management.ListMultiMaps
+
+object `package` extends ListMultiMaps {
+
+  implicit def request2Parameters[A](request: Request[A]) = new {
+    lazy val parameters: ListMultiMap[String, String] = {
+      val queryStringParameters = request.queryString mapValues { _.toList }
+      val bodyFormParameters: Map[String, List[String]] = request.body match {
+        case body: AnyContent if body.asFormUrlEncoded.isDefined => body.asFormUrlEncoded.get mapValues { _.toList }
+        case _ => Map()
+      }
+
+      queryStringParameters addBindings bodyFormParameters
+    }
+  }
+
+  implicit def request2RequestURI[A](request: Request[A]) = new {
+    lazy val requestURI: String = request.uri.replaceAll("\\?.*", "")
+  }
+}

--- a/management/src/main/scala/com/gu/management/responses.scala
+++ b/management/src/main/scala/com/gu/management/responses.scala
@@ -8,6 +8,7 @@ import scala.xml.Elem
  */
 trait Response {
   def sendTo(resp: HttpResponse)
+  def to(resp: HttpResponse) { sendTo(resp) }
 }
 
 case class PlainTextResponse(text: String) extends Response {

--- a/project/ManagementBuild.scala
+++ b/project/ManagementBuild.scala
@@ -1,22 +1,38 @@
 import sbt._
+import PlayProject._
+import sbt.PlayProject._
 
 object ManagementBuild extends Build {
-  lazy val root = Project("root", file(".")) aggregate(
+
+  lazy val root = Project("root", file(".")) aggregate (
     management,
     managementServletApi,
+    managementPlay,
     managementLogback,
     managementMongo,
-    exampleServletApi
+    exampleServletApi,
+    examplePlay
   )
 
   lazy val management = managementProject("management")
 
   lazy val managementServletApi = managementProject("management-servlet-api") dependsOn (management)
+  lazy val managementPlay = managementProject("management-play") dependsOn (management)
   lazy val managementLogback = managementProject("management-logback") dependsOn (management)
   lazy val managementMongo = managementProject("management-mongo") dependsOn  (management)
 
-  lazy val exampleServletApi = managementProject("example-servlet-api") dependsOn (management, managementServletApi, managementLogback)
+  lazy val exampleServletApi = managementProject("example-servlet-api") dependsOn (
+    management,
+    managementServletApi,
+    managementLogback
+  )
+
+  lazy val examplePlay = PlayProject(
+    name = "example-play",
+    applicationVersion = "1.0",
+    dependencies = Nil,
+    path = file("example-play"),
+    mainLang = SCALA) dependsOn (management, managementPlay, managementLogback)
 
   def managementProject(name: String) = Project(name, file(name))
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,8 @@ resolvers ++= Seq(
   "sbt-idea-repo" at "http://mpeltonen.github.com/maven/"
 )
 
+addSbtPlugin("play" % "sbt-plugin" % "2.0")
+
 addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbtscalariform" % "sbtscalariform" % "0.3.0")

--- a/readme.md
+++ b/readme.md
@@ -106,17 +106,13 @@ the HTTP interface in use in your desired web framework.
 Add the dependency to your build
 -----------------------------------
 
-In sbt 0.7.x:
-
-    val guardianGithubSnapshots = "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots"
-    val guManagement = "com.gu" %% "management-servlet-api" % "5.7-SNAPSHOT"
-
-In your build.sbt for sbt 0.10:
+In your build.sbt:
 
     resolvers += "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots"
     libraryDependencies += "com.gu" %% "management-servlet-api" % "5.7-SNAPSHOT"
 
-As of 4.1-SNAPSHOT, scala 2.8.1 and 2.9.0-1 are supported.
+As of 5.7, Scala 2.8.1 and 2.9.0-1 are no longer supported. Upgrade your project
+to Scala 2.9.1.
 
 Add the management filter to your web.xml
 --------------------------------------------
@@ -189,3 +185,72 @@ the
 [status page](https://github.com/guardian/guardian-management/blob/master/management/src/main/scala/com/gu/management/StatusPage.scala),
 and a more complex page that supports POSTs is
 [the switchboard](https://github.com/guardian/guardian-management/blob/master/management/src/main/scala/com/gu/management/switchables.scala).
+
+
+
+
+Getting Started (Play Framework)
+===============
+
+Add the dependency to your build
+-----------------------------------
+
+In your build.sbt for sbt 0.10:
+
+    resolvers += "Guardian Github Snapshots" at "http://guardian.github.com/maven/repo-snapshots"
+    libraryDependencies += "com.gu" %% "management-play" % "5.7-SNAPSHOT"
+
+As of 5.7, Scala 2.8.1 and 2.9.0-1 are no longer supported. Upgrade your project
+to Scala 2.9.1.
+
+Add the management controller to your routes
+--------------------------------------------
+
+Hook in the management URLs to your Play `conf/routes` file using the following:
+
+    GET     /management$path<.*>        controllers.Management.apply(path)
+    POST    /management$path<.*>        controllers.Management.apply(path)
+
+Implement the management controller
+-----------------------------------
+
+In `app/controllers/Management.scala` add the controller definition with the desired management
+pages:
+
+    object Management extends ManagementController {
+
+      lazy val pages =
+        new DummyPage() ::
+        new ManifestPage() ::
+        new Switchboard(Switches.all) ::
+        new StatusPage(TimingMetrics.all) ::
+        Nil
+    }
+
+Look at the example!
+-----------------------
+
+The [example project](https://github.com/guardian/guardian-management/tree/master/example-play) has
+management routes set up and uses some switches and timing metrics.
+
+    $ git clone git@github.com:guardian/guardian-management.git
+    $ cd guardian-management
+    $ ./sbt010
+    > project example-play
+    > run
+
+Try the following URLs locally:
+
+ * http://localhost:9000/scala-app
+ * http://localhost:9000/management
+ * http://localhost:9000/management/switchboard
+
+Also, enable the `take-it-down` switch and retry `/scala-app`.
+
+The application also has very simple custom management page, but the best thing to do if you want to write your
+own management pages is to look at how the pre-defined ones are implemented: a simple readonly page to look at is
+the
+[status page](https://github.com/guardian/guardian-management/blob/master/management/src/main/scala/com/gu/management/StatusPage.scala),
+and a more complex page that supports POSTs is
+[the switchboard](https://github.com/guardian/guardian-management/blob/master/management/src/main/scala/com/gu/management/switchables.scala).
+


### PR DESCRIPTION
Right, let's get going with this.

This adds /management URL support for Play Framework 2.0. See the example-play demo app and notice how similar the setup is to the example-servlet-api demo app.

The routes file entries are unfortunate, I think. My feeling is that the Play support could benefit from being made into a Play plugin somehow. The trick would be thinking up a clever way of configuring the management pages nicely from the client applications. _deferred_ 

Oh, support for Scala 2.8.1 and 2.9.0-1 is dropped. Pfaffing around with the `ManagementBuild.scala` to get it partially crossbuilding in `management-play` was too much too far.

I suggest releasing version 5.7 from here and worrying later about `RequestLoggingFilter` and other functionality that requires a code hook after the request completion. Play `Async` actions make this ever so slightly not trivial.

The key question is whether `PlayHttpResponse` is the right way about this. `ServletHttpResponse` writes immediate to the Serlvet API which isn't possible in Play. Instead, the write actions are stored and played later in the response at the natural point in the Play dispatch cycle. Clever thoughts on this in particular are welcome.
