### PR TITLE
Prevent exception with invalid auth string

### DIFF
--- a/management-servlet-api/src/main/scala/com/gu/management/servlet/ManagementFilter.scala
+++ b/management-servlet-api/src/main/scala/com/gu/management/servlet/ManagementFilter.scala
@@ -1,8 +1,9 @@
 package com.gu.management.servlet
 
-import com.gu.management.{ ManagementPage, IndexPage, ManagementBuildInfo, Loggable, UserProvider, UserCredentials }
 import javax.servlet._
-import javax.servlet.http.{ HttpServletResponse, HttpServletRequest }
+import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+
+import com.gu.management.{IndexPage, Loggable, ManagementBuildInfo, ManagementPage, UserCredentials, UserProvider}
 
 trait ManagementFilter extends AbstractHttpFilter with Loggable {
   lazy val version = ManagementBuildInfo.version
@@ -18,12 +19,13 @@ trait ManagementFilter extends AbstractHttpFilter with Loggable {
     pagesWithIndex find {
       _.canDispatch(httpRequest)
     } match {
-      case Some(page) if page.needsAuth => request.getHeaderOption("Authorization") match {
-        case Some(authString) if userProvider.isValid(extractCredentials(authString)) => {
-          page.dispatch(httpRequest).sendTo(httpResponse)
+      case Some(page) if page.needsAuth =>
+        request.getHeaderOption("Authorization") match {
+          case Some(authString) if userProvider.isValid(extractCredentials(authString)) =>
+            page.dispatch(httpRequest).sendTo(httpResponse)
+          case _ =>
+            response.sendNeedsAuthorisation(userProvider.realm)
         }
-        case _ => response.sendNeedsAuthorisation(userProvider.realm)
-      }
       case Some(page) => page.dispatch(httpRequest).sendTo(httpResponse)
       case _ => chain.doFilter(request, response)
     }
@@ -31,10 +33,10 @@ trait ManagementFilter extends AbstractHttpFilter with Loggable {
 
   lazy val pagesWithIndex = IndexPage(pages, applicationName, version) :: pages
 
-  private def extractCredentials(authString: String) = {
+  private def extractCredentials(authString: String): UserCredentials = {
     // authstring consists of "Basic Base64(user:pass)".
     authString.drop(6).base64Decoded.kv(":") match {
-      case (user, pass) => UserCredentials(user, pass)
+      case Some((user, pass)) => UserCredentials(user, pass)
       case _ => UserCredentials.missing
     }
   }

--- a/management-servlet-api/src/main/scala/com/gu/management/servlet/package.scala
+++ b/management-servlet-api/src/main/scala/com/gu/management/servlet/package.scala
@@ -7,18 +7,20 @@ import scalax.io.Resource
 object `package` {
 
   implicit def string2SplitAtFirst(s: String) = new {
-    def splitAtFirst(regex: String): (String, String) = s.split(regex) match {
-      case Array(_) => (s -> "")
-      case Array(prefix, rest) => (prefix -> rest)
+    def splitAtFirst(regex: String): Option[(String, String)] = s.split(regex) match {
+      case Array() => None
+      case Array(_) => Some(s -> "")
+      case Array(prefix, rest) => Some(prefix -> rest)
       case splits =>
-        splits(0) -> s.replaceFirst(splits(0), "").replaceFirst(regex, "")
+        Some(splits(0) -> s.replaceFirst(splits(0), "").replaceFirst(regex, ""))
     }
   }
 
   implicit def string2kv(s: String) = new {
-    def kv(delimiter: String): (String, String) = {
-      val (k, v) = s.splitAtFirst(delimiter)
-      k.trim -> v.trim
+    def kv(delimiter: String): Option[(String, String)] = {
+      for {
+        (k, v) <- s.splitAtFirst(delimiter)
+      } yield k.trim -> v.trim
     }
   }
 


### PR DESCRIPTION
Previously if you had an Authorization header, but it was invalid it was possible for the filter to ArrayIndexOutOfBounds. Now it should instead state that credentials are missing.
