### PR TITLE
Allow ManagementServer to start in a fixed port

### DIFF
--- a/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
+++ b/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
@@ -9,13 +9,11 @@ import java.io.StringWriter
 import scalax.file.Path
 
 object ManagementServer extends Loggable with PortFileHandling {
-  val managementPort = 18080
-  val managementLimit = 18099
-  val permittedPorts = managementPort to managementLimit
+  val permittedPorts = 18080 to 18099
   private var server: Option[HttpServer] = None
 
   def start(handler: ManagementHandler) {
-    startServer(managementPort, handler)
+    startServer(permittedPorts.min, handler)
   }
 
   def isRunning(): Boolean = server.isDefined

--- a/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
+++ b/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
@@ -16,8 +16,8 @@ object ManagementServer extends Loggable with PortFileHandling {
     startServer(permittedPorts.min, handler)
   }
 
-  def isRunning(): Boolean = server.isDefined
-  def port(): Int = server.get.getAddress.getPort
+  def isRunning: Boolean = server.isDefined
+  def port: Int = server.get.getAddress.getPort
 
   private def startServer(port: Int, handler: ManagementHandler) {
     synchronized {

--- a/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
+++ b/management-internal/src/main/scala/com/gu/management/internal/ManagementServer.scala
@@ -36,15 +36,15 @@ object ManagementServer extends Loggable with PortFileHandling {
 
     synchronized {
       if (server.nonEmpty) {
-        Left(s"Server already started. Running on port $port")
+        Left(s"Management server already started. Running on port $port")
       } else {
         try {
           val newServer = launchServer()
           createPortFile(handler.applicationName, newServer.getAddress.getPort)
           server = Some(newServer)
-          Right(s"Server started on port $bindToPort")
+          Right(s"Management server started on port $bindToPort")
         } catch {
-          case e: BindException => Left(s"Port $bindToPort in use.")
+          case e: BindException => Left(s"Cannot bind port $bindToPort. Already in use.")
         }
       }
     }

--- a/management-internal/src/test/scala/com/gu/management/internal/TestManagementServer.scala
+++ b/management-internal/src/test/scala/com/gu/management/internal/TestManagementServer.scala
@@ -2,41 +2,46 @@ package com.gu.management.internal
 
 import org.specs2.mutable._
 import com.gu.management.{ PlainTextResponse, Response, HttpRequest, ManagementPage }
-import io.Source
+import scala.io.Source
 
 class TestManagementServer extends Specification {
 
-  step {
-    val handler = new ManagementHandler {
-      def pages: List[ManagementPage] = List(
-        new ManagementPage {
-          def get(req: HttpRequest): Response = new PlainTextResponse("response")
-          val path: String = "/management/test"
-        }
-      )
-
-      val applicationName: String = "test"
-    }
-    ManagementServer.start(handler)
+  val handler = new ManagementHandler {
+    val applicationName: String = "test"
+    def pages: List[ManagementPage] = List(
+      new ManagementPage {
+        def get(req: HttpRequest): Response = new PlainTextResponse("response")
+        val path: String = "/management/test"
+      }
+    )
   }
 
   sequential
 
   "management server" should {
-    "bind to free port" in {
+    "bind to free port" in new Context {
+      ManagementServer.start(handler)
       ManagementServer.isRunning must beTrue
       ManagementServer.port must be greaterThanOrEqualTo (18080)
       ManagementServer.port must be lessThanOrEqualTo (18099)
     }
-    "serve a management page" in {
+    "serve a management page" in new Context {
+      ManagementServer.start(handler)
       val port = ManagementServer.port
       val response = Source.fromURL("http://localhost:%d/management/test" format port) mkString ""
       response must be equalTo ("response")
     }
+
+    "optionally bind to a fixed port" in new Context {
+      ManagementServer.start(handler, 18000)
+      ManagementServer.isRunning must beTrue
+      ManagementServer.port must be equalTo (18000)
+    }
   }
 
-  step {
-    ManagementServer.shutdown()
+  trait Context extends BeforeAfter {
+    def before: Any = {}
+    def after: Any = ManagementServer.shutdown()
   }
 
 }

--- a/management-internal/src/test/scala/com/gu/management/internal/TestManagementServer.scala
+++ b/management-internal/src/test/scala/com/gu/management/internal/TestManagementServer.scala
@@ -25,11 +25,11 @@ class TestManagementServer extends Specification {
   "management server" should {
     "bind to free port" in {
       ManagementServer.isRunning must beTrue
-      ManagementServer.port() must be greaterThanOrEqualTo (18080)
-      ManagementServer.port() must be lessThanOrEqualTo (18099)
+      ManagementServer.port must be greaterThanOrEqualTo (18080)
+      ManagementServer.port must be lessThanOrEqualTo (18099)
     }
     "serve a management page" in {
-      val port = ManagementServer.port()
+      val port = ManagementServer.port
       val response = Source.fromURL("http://localhost:%d/management/test" format port) mkString ""
       response must be equalTo ("response")
     }

--- a/management-servlet-api/src/main/scala/com/gu/management/servlet/ManagementFilter.scala
+++ b/management-servlet-api/src/main/scala/com/gu/management/servlet/ManagementFilter.scala
@@ -1,9 +1,9 @@
 package com.gu.management.servlet
 
 import javax.servlet._
-import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
+import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 
-import com.gu.management.{IndexPage, Loggable, ManagementBuildInfo, ManagementPage, UserCredentials, UserProvider}
+import com.gu.management.{ IndexPage, Loggable, ManagementBuildInfo, ManagementPage, UserCredentials, UserProvider }
 
 trait ManagementFilter extends AbstractHttpFilter with Loggable {
   lazy val version = ManagementBuildInfo.version


### PR DESCRIPTION
We are running multiple microservices in the same box, each with the `guardian-management-play` lib inside.

The non-deterministic behaviour of the management server port (depending on the start order of each microservice) is making it hard to setup loadbalancers and healthchecks before hand (reading it from `/var/run/ports/appname.port` is not practical in our particular setup).

This PR adds the _possibility_ to launch the ManagementServer in a fixed port, but leaves the existing functionality as-is:
- If no fixed port is defined, it applies the previous behaviour of attempting to launch in the first free port from the list of permitted ports.
- If it fails to bind to the fixed port, it logs an error and _does not try_ to launch in another port.

I have also another dependent change for `guardian-management-play` to expose the functionality added in this PR: https://github.com/guardian/guardian-management-play/pull/7
