### PR TITLE
Attempt to fix release process

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,9 +29,9 @@ pomExtra in ThisBuild := {
 
 import ReleaseTransformations._
 
-releaseCrossBuild in ThisBuild := true
+releaseCrossBuild := true
 
-releaseProcess in ThisBuild := Seq[ReleaseStep](
+releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,


### PR DESCRIPTION
When running a release, the publishSigned and sonatypeReleaseAll command weren't run, so these had to be done as a separate manual step with the tag checked out.