### PR TITLE
Disable body caching for multipart requests.

### DIFF
--- a/management-servlet-api/src/main/scala/com/gu/management/servlet/RequestLoggingFilter.scala
+++ b/management-servlet-api/src/main/scala/com/gu/management/servlet/RequestLoggingFilter.scala
@@ -80,7 +80,10 @@ class RequestLoggingFilter(
   }
 
   def doHttpFilter(request: HttpServletRequest, response: HttpServletResponse, chain: FilterChain) {
-    val logPostData = logRequestBodySwitch.isSwitchedOn && List("POST", "PUT").contains(request.getMethod)
+    // We don't want to use the BodyCaching wrapper on multipart file uploads, as this calls request.getBody, which exhausts the request
+    // and breaks calls to fileParams in scalatra
+    val isMultiPartUpload = request.getContentType.startsWith("multipart/")
+    val logPostData = logRequestBodySwitch.isSwitchedOn && List("POST", "PUT").contains(request.getMethod) && !isMultiPartUpload
     val wrappedRequest = if (logPostData) BodyCachingRequestWrapper(request) else request
 
     val req = new Request(wrappedRequest)


### PR DESCRIPTION
This is something of a hack, but is required for Scalatra's [fileupload functionality](http://scalatra.org/guides/2.6/formats/upload.html) to work. Otherwise the call to `getBody` in BodyCachingRequestWrapper exhausts the request, making any files included in it unavailable to any controllers.